### PR TITLE
Start using SerialPort DataReceived event instead of timer loop

### DIFF
--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -6,88 +6,93 @@ using System.Windows.Threading;
 
 namespace RetroSpy
 {
-    public delegate void PacketEventHandler (object sender, byte[] packet);
+    public delegate void PacketEventHandler(object sender, byte[] packet);
 
     public class SerialMonitor
     {
         const int BAUD_RATE = 115200;
-        const int TIMER_MS  = 7;
+        const int TIMER_MS = 7;
 
         public event PacketEventHandler PacketReceived;
         public event EventHandler Disconnected;
 
         SerialPort _datPort;
-        List <byte> _localBuffer;
+        List<byte> _localBuffer;
 
         DispatcherTimer _timer;
 
-        public SerialMonitor (string portName)
+        public SerialMonitor(string portName)
         {
-            _localBuffer = new List <byte> ();
-            _datPort = new SerialPort (portName, BAUD_RATE);
+            _localBuffer = new List<byte>();
+            _datPort = new SerialPort(portName, BAUD_RATE);
         }
 
-        public void Start ()
+        public void Start()
         {
             if (_timer != null) return;
 
-            _localBuffer.Clear ();
-            _datPort.Open ();
+            _localBuffer.Clear();
+            _datPort.Open();
 
-            _timer = new DispatcherTimer ();
-            _timer.Interval = TimeSpan.FromMilliseconds (TIMER_MS); 
+            _timer = new DispatcherTimer();
+            _timer.Interval = TimeSpan.FromMilliseconds(TIMER_MS);
             _timer.Tick += tick;
-            _timer.Start ();
+            _timer.Start();
         }
 
-        public void Stop ()
+        public void Stop()
         {
-            if (_datPort != null) {
-                try { // If the device has been unplugged, Close will throw an IOException.  This is fine, we'll just keep cleaning up.
-                    _datPort.Close ();
+            if (_datPort != null)
+            {
+                try
+                { // If the device has been unplugged, Close will throw an IOException.  This is fine, we'll just keep cleaning up.
+                    _datPort.Close();
                 }
-                catch (IOException) {}
+                catch (IOException) { }
                 _datPort = null;
             }
-            if (_timer != null) {
-                _timer.Stop ();
+            if (_timer != null)
+            {
+                _timer.Stop();
                 _timer = null;
             }
         }
 
-        void tick (object sender, EventArgs e)
+        void tick(object sender, EventArgs e)
         {
             if (_datPort == null || !_datPort.IsOpen || PacketReceived == null) return;
 
             // Try to read some data from the COM port and append it to our localBuffer.
             // If there's an IOException then the device has been disconnected.
-            try {
+            try
+            {
                 int readCount = _datPort.BytesToRead;
                 if (readCount < 1) return;
-                byte[] readBuffer = new byte [readCount];
-                _datPort.Read (readBuffer, 0, readCount);
-                _datPort.DiscardInBuffer ();
-                _localBuffer.AddRange (readBuffer);
+                byte[] readBuffer = new byte[readCount];
+                _datPort.Read(readBuffer, 0, readCount);
+                _datPort.DiscardInBuffer();
+                _localBuffer.AddRange(readBuffer);
             }
-            catch (IOException) {
-                Stop ();
-                if (Disconnected != null) Disconnected (this, EventArgs.Empty);
+            catch (IOException)
+            {
+                Stop();
+                if (Disconnected != null) Disconnected(this, EventArgs.Empty);
                 return;
             }
 
             // Try and find 2 splitting characters in our buffer.
-            int lastSplitIndex = _localBuffer.LastIndexOf (0x0A);
+            int lastSplitIndex = _localBuffer.LastIndexOf(0x0A);
             if (lastSplitIndex <= 1) return;
-            int sndLastSplitIndex = _localBuffer.LastIndexOf (0x0A, lastSplitIndex - 1);
+            int sndLastSplitIndex = _localBuffer.LastIndexOf(0x0A, lastSplitIndex - 1);
             if (lastSplitIndex == -1) return;
 
             // Grab the latest packet out of the buffer and fire it off to the receive event listeners.
             int packetStart = sndLastSplitIndex + 1;
-            int packetSize  = lastSplitIndex - packetStart;
-            PacketReceived (this, _localBuffer.GetRange (packetStart, packetSize).ToArray ());
+            int packetSize = lastSplitIndex - packetStart;
+            PacketReceived(this, _localBuffer.GetRange(packetStart, packetSize).ToArray());
 
             // Clear our buffer up until the last split character.
-            _localBuffer.RemoveRange (0, lastSplitIndex);
+            _localBuffer.RemoveRange(0, lastSplitIndex);
         }
     }
 }


### PR DESCRIPTION
The results should always come in faster than they would on a timer.  In my (limited) testing, fast inputs are no longer being dropped.