### PR TITLE
Rename Sega and Classic to Genesis and SMS

### DIFF
--- a/firmware/GenesisControllerSpy.cpp
+++ b/firmware/GenesisControllerSpy.cpp
@@ -1,5 +1,5 @@
 //
-// SegaControllerSpy.cpp
+// GenesisControllerSpy.cpp
 //
 // Author:
 //       Christopher Mallery <christopher.mallery@gmail.com>
@@ -25,9 +25,9 @@
 // THE SOFTWARE.
 
 #include "Arduino.h"
-#include "SegaControllerSpy.h"
+#include "GenesisControllerSpy.h"
 
-SegaControllerSpy::SegaControllerSpy()
+GenesisControllerSpy::GenesisControllerSpy()
 {
     // Setup input pins
     // Assumes pin 8 is SELECT (DB9 pin 7)
@@ -85,7 +85,7 @@ SegaControllerSpy::SegaControllerSpy()
 #define WAIT_FALLING_EDGEB( pin ) while( !PINB_READ(pin) ); while( PINB_READ(pin) );
 #define WAIT_LEADING_EDGEB( pin ) while( PINB_READ(pin) ); while( !PINB_READ(pin) );
 
-void SegaControllerSpy::getMouseState(byte data[3])
+void GenesisControllerSpy::getMouseState(byte data[3])
 {
   unsigned long reads = 0;
 
@@ -112,7 +112,7 @@ void SegaControllerSpy::getMouseState(byte data[3])
   interrupts();
 }
 
-word SegaControllerSpy::getState()
+word GenesisControllerSpy::getState()
 {
     word currentState = 0xFFFF;
     bool check6 = false;

--- a/firmware/GenesisControllerSpy.h
+++ b/firmware/GenesisControllerSpy.h
@@ -1,5 +1,5 @@
 //
-// SegaControllerSpy.h
+// GenesisControllerSpy.h
 //
 // Author:
 //       Christopher Mallery <christopher.mallery@gmail.com>
@@ -24,8 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef SegaControllerSpy_h
-#define SegaControllerSpy_h
+#ifndef GenesisControllerSpy_h
+#define GenesisControllerSpy_h
 
 enum
 {
@@ -44,9 +44,9 @@ enum
     SCS_BTN_MODE  = 4096
 };
 
-class SegaControllerSpy {
+class GenesisControllerSpy {
     public:
-        SegaControllerSpy();
+        GenesisControllerSpy();
         word getState();
         void getMouseState(byte data[3]);
 

--- a/firmware/SMSControllerSpy.cpp
+++ b/firmware/SMSControllerSpy.cpp
@@ -1,5 +1,5 @@
 //
-// ClassicControllerSpySpy.cpp
+// SMSControllerSpy.cpp
 //
 // Author:
 //       Christopher Mallery <christopher.mallery@gmail.com>
@@ -25,9 +25,9 @@
 // THE SOFTWARE.
 
 #include "Arduino.h"
-#include "ClassicControllerSpy.h"
+#include "SMSControllerSpy.h"
 
-ClassicControllerSpy::ClassicControllerSpy(byte db9_pin_1, byte db9_pin_2, byte db9_pin_3, byte db9_pin_4, byte db9_pin_6, byte db9_pin_9)
+SMSControllerSpy::SMSControllerSpy(byte db9_pin_1, byte db9_pin_2, byte db9_pin_3, byte db9_pin_4, byte db9_pin_6, byte db9_pin_9)
 {
     // Set pins
     _inputPins[0] = db9_pin_1;
@@ -47,7 +47,7 @@ ClassicControllerSpy::ClassicControllerSpy(byte db9_pin_1, byte db9_pin_2, byte 
     _lastReadTime = millis();
 }
 
-word ClassicControllerSpy::getState()
+word SMSControllerSpy::getState()
 {
     if (max(millis() - _lastReadTime, 0) < CC_READ_DELAY_MS)
     {
@@ -69,7 +69,7 @@ word ClassicControllerSpy::getState()
     return _currentState;
 }
 
-void ClassicControllerSpy::readCycle()
+void SMSControllerSpy::readCycle()
 {
 	// Read input pins for Up, Down, Left, Right, 1, 2
 	while(_inputPins[2] == LOW && _inputPins[3] == LOW){}

--- a/firmware/SMSControllerSpy.h
+++ b/firmware/SMSControllerSpy.h
@@ -1,5 +1,5 @@
 //
-// ClassicControllerSpy.h
+// SMSControllerSpy.h
 //
 // Author:
 //       Christopher Mallery <christopher.mallery@gmail.com>
@@ -24,8 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef ClassicControllerSpy_h
-#define ClassicControllerSpy_h
+#ifndef SMSControllerSpy_h
+#define SMSControllerSpy_h
 
 enum
 {
@@ -41,9 +41,9 @@ const byte CC_INPUT_PINS = 6;
 
 const unsigned long CC_READ_DELAY_MS = 5;
 
-class ClassicControllerSpy {
+class SMSControllerSpy {
     public:
-        ClassicControllerSpy(byte db9_pin_1, byte db9_pin_2, byte db9_pin_3, byte db9_pin_4, byte db9_pin_6, byte db9_pin_9);
+        SMSControllerSpy(byte db9_pin_1, byte db9_pin_2, byte db9_pin_3, byte db9_pin_4, byte db9_pin_6, byte db9_pin_9);
 
         word getState();
 


### PR DESCRIPTION
This is going to make future changes much easier, without having to know about legacy naming decisions.

This patch will be a pre-requisite for another very large change that I'm making.