### PR TITLE
Split debugging functions away from their write functions.

### DIFF
--- a/firmware/BoosterGrip.cpp
+++ b/firmware/BoosterGrip.cpp
@@ -29,28 +29,28 @@
 void BoosterGripSpy::setup() {
     // TODO: Move these pin numbers to config.h
     // Set pins
-    _inputPins[0] = 2;
-    _inputPins[1] = 3;
-    _inputPins[2] = 4;
-    _inputPins[3] = 5;
-    _inputPins[4] = 6;
-    _inputPins[5] = 7;
-    _inputPins[6] = 8;
+    inputPins[0] = 2;
+    inputPins[1] = 3;
+    inputPins[2] = 4;
+    inputPins[3] = 5;
+    inputPins[4] = 6;
+    inputPins[5] = 7;
+    inputPins[6] = 8;
 
     // Setup input pins
     for (byte i = 0; i < BG_INPUT_PINS; i++) {
         if (i == 4 || i == 6) {
-            pinMode(_inputPins[i], INPUT);
+            pinMode(inputPins[i], INPUT);
         } else {
-            pinMode(_inputPins[i], INPUT_PULLUP);
+            pinMode(inputPins[i], INPUT_PULLUP);
         }
     }
 
-    _lastReadTime = millis();
+    lastReadTime = millis();
 }
 
 void BoosterGripSpy::loop() {
-    if (max(millis() - _lastReadTime, 0) < BG_READ_DELAY_MS)
+    if (max(millis() - lastReadTime, 0) < BG_READ_DELAY_MS)
     {
         // Not enough time has elapsed, return
         return;
@@ -59,29 +59,34 @@ void BoosterGripSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 
-    _lastReadTime = millis();
+    lastReadTime = millis();
 }
 
 void BoosterGripSpy::updateState() {
     // Read input pins for Up, Down, Left, Right, 1, 2, 3
-    if (digitalRead(_inputPins[0]) == LOW) { _currentState |= BG_BTN_UP; }
-    if (digitalRead(_inputPins[1]) == LOW) { _currentState |= BG_BTN_DOWN; }
-    if (digitalRead(_inputPins[2]) == LOW) { _currentState |= BG_BTN_LEFT; }
-    if (digitalRead(_inputPins[3]) == LOW) { _currentState |= BG_BTN_RIGHT; }
-    if (digitalRead(_inputPins[4]) == HIGH) { _currentState |= BG_BTN_3; }
-    if (digitalRead(_inputPins[5]) == LOW)  { _currentState |= BG_BTN_1; }
-    if (digitalRead(_inputPins[6]) == HIGH) { _currentState |= BG_BTN_2; }
+    if (digitalRead(inputPins[0]) == LOW) { currentState |= BG_BTN_UP; }
+    if (digitalRead(inputPins[1]) == LOW) { currentState |= BG_BTN_DOWN; }
+    if (digitalRead(inputPins[2]) == LOW) { currentState |= BG_BTN_LEFT; }
+    if (digitalRead(inputPins[3]) == LOW) { currentState |= BG_BTN_RIGHT; }
+    if (digitalRead(inputPins[4]) == HIGH) { currentState |= BG_BTN_3; }
+    if (digitalRead(inputPins[5]) == LOW)  { currentState |= BG_BTN_1; }
+    if (digitalRead(inputPins[6]) == HIGH) { currentState |= BG_BTN_2; }
 }
 
 void BoosterGripSpy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 7; ++i) {
-      Serial.write (currentState & (1 << i) ? ONE : ZERO );
+        Serial.write (currentState & (1 << i) ? ONE : ZERO );
     }
     Serial.write( SPLIT );
-#else
+}
+
+void BoosterGripSpy::debugSerial() {
     if (currentState != lastState) {
         Serial.print((currentState & BG_BTN_UP)    ? "U" : "0");
         Serial.print((currentState & BG_BTN_DOWN)  ? "D" : "0");
@@ -93,5 +98,4 @@ void BoosterGripSpy::writeSerial() {
         Serial.print("\n");
         lastState = currentState;
     }
-#endif
 }

--- a/firmware/BoosterGrip.h
+++ b/firmware/BoosterGrip.h
@@ -34,14 +34,16 @@ class BoosterGripSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:
-        word _currentState;
+        word currentState;
+	word lastState = -1;
 
-        unsigned long _lastReadTime;
+        unsigned long lastReadTime;
 
-        byte _inputPins[BG_INPUT_PINS];
+        byte inputPins[BG_INPUT_PINS];
 
         enum buttonTypes {
             BG_BTN_UP    = 1,

--- a/firmware/ColecoVision.cpp
+++ b/firmware/ColecoVision.cpp
@@ -11,3 +11,6 @@ void ColecoVisionSpy::updateState() {
 
 void ColecoVisionSpy::writeSerial() {
 }
+
+void ColecoVisionSpy::debugSerial() {
+}

--- a/firmware/ColecoVision.h
+++ b/firmware/ColecoVision.h
@@ -8,6 +8,7 @@ class ColecoVisionSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/ControllerSpy.h
+++ b/firmware/ControllerSpy.h
@@ -4,11 +4,12 @@
 #include "common.h"
 
 class ControllerSpy {
-	public:
-		virtual void setup();
-		virtual void loop();
-		virtual void writeSerial();
-		virtual void updateState();
+    public:
+        virtual void setup();
+        virtual void loop();
+        virtual void writeSerial();
+        virtual void debugSerial();
+        virtual void updateState();
 };
 
 #endif

--- a/firmware/FMTowns.cpp
+++ b/firmware/FMTowns.cpp
@@ -7,7 +7,11 @@ void FMTownsSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void FMTownsSpy::updateState() {
@@ -23,15 +27,15 @@ void FMTownsSpy::updateState() {
 }
 
 void FMTownsSpy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 9; ++i) {
         Serial.write(rawData[i] ? ZERO : ONE);
     }
     Serial.write( SPLIT );
-#else
+}
+
+void FMTownsSpy::debugSerial() {
     for(int i = 0; i < 9; ++i) {
         Serial.print(rawData[i] ? "0" : "1");
     }
     Serial.print("\n");
-#endif
 }

--- a/firmware/FMTowns.h
+++ b/firmware/FMTowns.h
@@ -8,6 +8,7 @@ class FMTownsSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/GC.cpp
+++ b/firmware/GC.cpp
@@ -12,7 +12,11 @@ void GCSpy::loop() {
         if (checkPrefixGC()) {
             sendRawData(rawData, GC_PREFIX, GC_BITCOUNT);
         } else if (checkPrefixGBA()) {
+#if !defined(DEBUG)
             writeSerial();
+#else
+            debugSerial();
+#endif
         } else if (checkBothGCPrefixOnRaphnet()) {
            // Sets seenGC2N64RaphnetAdapter to true
         }
@@ -22,11 +26,15 @@ void GCSpy::loop() {
         updateState();
         interrupts();
         if (checkBothGCPrefixOnRaphnet()) {
-          sendRawData(rawData, 34 + GC_PREFIX, GC_BITCOUNT);
+            sendRawData(rawData, 34 + GC_PREFIX, GC_BITCOUNT);
         } else if (checkPrefixGC()) {
-          sendRawData(rawData, GC_PREFIX, GC_BITCOUNT);
+            sendRawData(rawData, GC_PREFIX, GC_BITCOUNT);
         } else if (checkPrefixGBA()) {
-          writeSerial();
+#if !defined(DEBUG)
+            writeSerial();
+#else
+            debugSerial();
+#endif
         }
     }
 }
@@ -53,65 +61,65 @@ read_loop:
 }
 
 void GCSpy::writeSerial() {
-#ifndef DEBUG
-  Serial.write(ZERO);
-  Serial.write(ZERO);
-  Serial.write(ZERO);
-  Serial.write(rawData[21] ? ONE : ZERO);
-  Serial.write(ZERO);
-  Serial.write(ZERO);
-  Serial.write(rawData[23] ? ONE : ZERO);
-  Serial.write(rawData[24] ? ONE : ZERO);
-  Serial.write(ZERO);
-  Serial.write(rawData[31] ? ONE : ZERO);
-  Serial.write(rawData[32] ? ONE : ZERO);
-  Serial.write(rawData[22] ? ONE : ZERO);
-  Serial.write(rawData[18] ? ONE : ZERO);
-  Serial.write(rawData[17] ? ONE : ZERO);
-  Serial.write(rawData[20] ? ONE : ZERO);
-  Serial.write(rawData[19] ? ONE : ZERO);
-  Serial.write(ONE);
-  for(int i = 0; i < 7; ++i)
     Serial.write(ZERO);
-  Serial.write(ONE);
-  for(int i = 0; i < 7; ++i)
     Serial.write(ZERO);
-  Serial.write(ONE);
-  for(int i = 0; i < 7; ++i)
     Serial.write(ZERO);
-  Serial.write(ONE);
-  for(int i = 0; i < 7; ++i)
+    Serial.write(rawData[21] ? ONE : ZERO);
     Serial.write(ZERO);
-  for(int i = 0; i < 8; ++i)
     Serial.write(ZERO);
-  for(int i = 0; i < 8; ++i)
+    Serial.write(rawData[23] ? ONE : ZERO);
+    Serial.write(rawData[24] ? ONE : ZERO);
     Serial.write(ZERO);
-  Serial.write(SPLIT);
-#else
-  Serial.print("0");
-  Serial.print("0");
-  Serial.print("0");
-  Serial.print(rawData[21] ? "t" : "0");
-  Serial.print("0");
-  Serial.print("0");
-  Serial.print(rawData[23] ? "b" : "0");
-  Serial.print(rawData[24] ? "a" : "0");
-  Serial.print("0");
-  Serial.print(rawData[31] ? "L" : "0");
-  Serial.print(rawData[32] ? "R" : "0");
-  Serial.print(rawData[22] ? "s" : "0");
-  Serial.print(rawData[18] ? "u" : "0");
-  Serial.print(rawData[17] ? "d" : "0");
-  Serial.print(rawData[20] ? "l" : "0");
-  Serial.print(rawData[19] ? "r" : "0");
-  Serial.print(128);
-  Serial.print(128);
-  Serial.print(128);
-  Serial.print(128);
-  Serial.print(0);
-  Serial.print(0);
-  Serial.print("\n");
-#endif
+    Serial.write(rawData[31] ? ONE : ZERO);
+    Serial.write(rawData[32] ? ONE : ZERO);
+    Serial.write(rawData[22] ? ONE : ZERO);
+    Serial.write(rawData[18] ? ONE : ZERO);
+    Serial.write(rawData[17] ? ONE : ZERO);
+    Serial.write(rawData[20] ? ONE : ZERO);
+    Serial.write(rawData[19] ? ONE : ZERO);
+    Serial.write(ONE);
+    for(int i = 0; i < 7; ++i)
+        Serial.write(ZERO);
+    Serial.write(ONE);
+    for(int i = 0; i < 7; ++i)
+        Serial.write(ZERO);
+    Serial.write(ONE);
+    for(int i = 0; i < 7; ++i)
+        Serial.write(ZERO);
+    Serial.write(ONE);
+    for(int i = 0; i < 7; ++i)
+        Serial.write(ZERO);
+    for(int i = 0; i < 8; ++i)
+        Serial.write(ZERO);
+    for(int i = 0; i < 8; ++i)
+        Serial.write(ZERO);
+    Serial.write(SPLIT);
+}
+
+void GCSpy::debugSerial() {
+    Serial.print("0");
+    Serial.print("0");
+    Serial.print("0");
+    Serial.print(rawData[21] ? "t" : "0");
+    Serial.print("0");
+    Serial.print("0");
+    Serial.print(rawData[23] ? "b" : "0");
+    Serial.print(rawData[24] ? "a" : "0");
+    Serial.print("0");
+    Serial.print(rawData[31] ? "L" : "0");
+    Serial.print(rawData[32] ? "R" : "0");
+    Serial.print(rawData[22] ? "s" : "0");
+    Serial.print(rawData[18] ? "u" : "0");
+    Serial.print(rawData[17] ? "d" : "0");
+    Serial.print(rawData[20] ? "l" : "0");
+    Serial.print(rawData[19] ? "r" : "0");
+    Serial.print(128);
+    Serial.print(128);
+    Serial.print(128);
+    Serial.print(128);
+    Serial.print(0);
+    Serial.print(0);
+    Serial.print("\n");
 }
 
 inline bool GCSpy::checkPrefixGBA()

--- a/firmware/GC.h
+++ b/firmware/GC.h
@@ -8,6 +8,7 @@ class GCSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/Genesis.cpp
+++ b/firmware/Genesis.cpp
@@ -43,7 +43,11 @@ void GenesisSpy::setup() {
 
 void GenesisSpy::loop() {
     updateState();
-    sendRawGenesisData();
+#if !defined(DEBUG)
+    writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void GenesisSpy::updateState() {
@@ -102,30 +106,30 @@ void GenesisSpy::updateState() {
 }
 
 void GenesisSpy::writeSerial() {
-#ifndef DEBUG
-  for (unsigned char i = 0; i < 13; ++i)
-  {
-    Serial.write(currentState & (1 << i) ? ONE : ZERO);
-  }
-  Serial.write(SPLIT);
-#else
-  if (currentState != lastState)
-  {
-      Serial.print((currentState & SCS_CTL_ON)    ? "+" : "-");
-      Serial.print((currentState & SCS_BTN_UP)    ? "U" : "0");
-      Serial.print((currentState & SCS_BTN_DOWN)  ? "D" : "0");
-      Serial.print((currentState & SCS_BTN_LEFT)  ? "L" : "0");
-      Serial.print((currentState & SCS_BTN_RIGHT) ? "R" : "0");
-      Serial.print((currentState & SCS_BTN_START) ? "S" : "0");
-      Serial.print((currentState & SCS_BTN_A)     ? "A" : "0");
-      Serial.print((currentState & SCS_BTN_B)     ? "B" : "0");
-      Serial.print((currentState & SCS_BTN_C)     ? "C" : "0");
-      Serial.print((currentState & SCS_BTN_X)     ? "X" : "0");
-      Serial.print((currentState & SCS_BTN_Y)     ? "Y" : "0");
-      Serial.print((currentState & SCS_BTN_Z)     ? "Z" : "0");
-      Serial.print((currentState & SCS_BTN_MODE)  ? "M" : "0");
-      Serial.print("\n");
-      lastState = currentState;
-  }
-#endif
+    for (unsigned char i = 0; i < 13; ++i)
+    {
+        Serial.write(currentState & (1 << i) ? ONE : ZERO);
+    }
+    Serial.write(SPLIT);
+}
+
+void GenesisSpy::debugSerial() {
+    if (currentState != lastState)
+    {
+        Serial.print((currentState & SCS_CTL_ON)    ? "+" : "-");
+        Serial.print((currentState & SCS_BTN_UP)    ? "U" : "0");
+        Serial.print((currentState & SCS_BTN_DOWN)  ? "D" : "0");
+        Serial.print((currentState & SCS_BTN_LEFT)  ? "L" : "0");
+        Serial.print((currentState & SCS_BTN_RIGHT) ? "R" : "0");
+        Serial.print((currentState & SCS_BTN_START) ? "S" : "0");
+        Serial.print((currentState & SCS_BTN_A)     ? "A" : "0");
+        Serial.print((currentState & SCS_BTN_B)     ? "B" : "0");
+        Serial.print((currentState & SCS_BTN_C)     ? "C" : "0");
+        Serial.print((currentState & SCS_BTN_X)     ? "X" : "0");
+        Serial.print((currentState & SCS_BTN_Y)     ? "Y" : "0");
+        Serial.print((currentState & SCS_BTN_Z)     ? "Z" : "0");
+        Serial.print((currentState & SCS_BTN_MODE)  ? "M" : "0");
+        Serial.print("\n");
+        lastState = currentState;
+    }
 }

--- a/firmware/Genesis.h
+++ b/firmware/Genesis.h
@@ -49,6 +49,7 @@ class GenesisSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/GenesisMouse.h
+++ b/firmware/GenesisMouse.h
@@ -34,9 +34,11 @@ class GenesisMouseSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:
+        unsigned char rawData[24];
         const uint8_t TH = 0  // Pin 8, 0 on PINB
         const uint8_t TR = 7  // Pin 7
         const uint8_t TL = 6  // Pin 6

--- a/firmware/Intellivision.cpp
+++ b/firmware/Intellivision.cpp
@@ -7,7 +7,11 @@ void IntellivisionSpy::loop() {
     noInterrupts();
     read_IntellivisionData();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void IntellivisionSpy::updateState() {
@@ -99,12 +103,13 @@ void IntellivisionSpy::updateState() {
 }
 
 void IntellivisionSpy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 32; ++i) {
         Serial.write(rawData[i]);
     }
     Serial.write(SPLIT);
-#else
+}
+
+void IntellivisionSpy::debugSerial() {
     Serial.print(intRawData);
     Serial.print("|");
     for(int i = 0; i < 16; ++i) {
@@ -119,5 +124,4 @@ void IntellivisionSpy::writeSerial() {
         Serial.print(rawData[i + 28]);
     }
     Serial.print("\n");
-#endif
 }

--- a/firmware/Intellivision.h
+++ b/firmware/Intellivision.h
@@ -8,6 +8,7 @@ class IntellivisionSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/Jaguar.cpp
+++ b/firmware/Jaguar.cpp
@@ -1,17 +1,21 @@
 #include "Jaguar.h"
 
-void SkelSpy::setup() {
+void JaguarSpy::setup() {
 }
 
-void SkelSpy::loop() {
+void JaguarSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
     delay(1);
 }
 
-void SkelSpy::updateState() {
+void JaguarSpy::updateState() {
     WAIT_FALLING_EDGEB(0);
     asm volatile( MICROSECOND_NOPS MICROSECOND_NOPS MICROSECOND_NOPS MICROSECOND_NOPS);
     rawData[3] = (PIND & 0b11111000);
@@ -29,14 +33,15 @@ void SkelSpy::updateState() {
     rawData[0] = (PIND & 0b11111100);
 }
 
-void SkelSpy::writeSerial() {
-#ifndef DEBUG
+void JaguarSpy::writeSerial() {
     Serial.write(rawData[0]);
     Serial.write(rawData[1]);
     Serial.write(rawData[2]);
     Serial.write(rawData[3]);
     Serial.write(SPLIT);
-#else 
+}
+
+void JaguarSpy::debugSerial() {
     Serial.print((rawData[0] & 0b00000100) == 0 ? "P" : "0");
     Serial.print((rawData[0] & 0b00001000) == 0 ? "A" : "0");
     Serial.print((rawData[0] & 0b00010000) == 0 ? "R" : "0");
@@ -66,5 +71,4 @@ void SkelSpy::writeSerial() {
     Serial.print((rawData[3] & 0b10000000) == 0 ? "#" : "0");
 
     Serial.print("\n");
-#endif
 }

--- a/firmware/Jaguar.h
+++ b/firmware/Jaguar.h
@@ -8,6 +8,7 @@ class JaguarSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/N64.cpp
+++ b/firmware/N64.cpp
@@ -8,7 +8,11 @@ void N64Spy::loop() {
     updateState();
     interrupts();
     if (checkPrefixN64()) {
+#if !defined(DEBUG)
         writeSerial();
+#else
+        debugSerial();
+#endif
     } else {
       // This makes no sense, but its needed after command 0x0 or else you get garbage on the line
       delay(2);
@@ -100,21 +104,21 @@ read_loop:
 void N64Spy::writeSerial() {
     const unsigned char first = 2;
 
-    #ifndef DEBUG
-    for( unsigned char i = first ; i < first + N64_BITCOUNT ; i++ ) {
-        Serial.write( rawData[i] ? ONE : ZERO );
+    for(unsigned char i = first ; i < first + N64_BITCOUNT ; i++) {
+        Serial.write(rawData[i] ? ONE : ZERO);
     }
-    Serial.write( SPLIT );
-    #else
+    Serial.write(SPLIT);
+}
+
+void N64Spy::debugSerial() {
     Serial.print(rawData[0]);
     Serial.print("|");
     int j = 0;
     for( unsigned char i = 0 ; i < 32; i++ ) {
         if (j % 8 == 0 && j != 0)
-          Serial.print("|");
-        Serial.print( rawData[i+2] ? "1" : "0" );
+            Serial.print("|");
+        Serial.print(rawData[i+2] ? "1" : "0");
         j++;
     }
     Serial.print("\n");
-    #endif
 }

--- a/firmware/N64.h
+++ b/firmware/N64.h
@@ -8,6 +8,7 @@ class N64Spy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/NES.cpp
+++ b/firmware/NES.cpp
@@ -5,20 +5,27 @@ void NESSpy::setup() {
 
 void NESSpy::loop() {
     noInterrupts();
-#ifdef MODE_2WIRE_NES
-    read_shiftRegister_2wire(NES_LATCH, NES_DATA, true, NES_BITCOUNT);
-#else
     updateState();
-#endif
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void NESSpy::writeSerial() {
     sendRawData(rawData, 0, NES_BITCOUNT * 3);
 }
 
+void NESSpy::debugSerial() {
+    sendRawDataDebug(rawData, 0, NES_BITCOUNT * 3);
+}
+
 void NESSpy::updateState() {
+#ifdef MODE_2WIRE_NES
+    read_shiftRegister_2wire(rawData, NES_LATCH, NES_DATA, true, NES_BITCOUNT);
+#else
     unsigned char bits = NES_BITCOUNT;
     unsigned char *rawDataPtr = rawData;
 
@@ -32,4 +39,5 @@ void NESSpy::updateState() {
         ++rawDataPtr;
     }
     while(--bits > 0);
+#endif
 }

--- a/firmware/NES.h
+++ b/firmware/NES.h
@@ -8,6 +8,7 @@ class NESSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/NeoGeo.cpp
+++ b/firmware/NeoGeo.cpp
@@ -7,7 +7,11 @@ void NeoGeoSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void NeoGeoSpy::updateState() {
@@ -24,17 +28,15 @@ void NeoGeoSpy::updateState() {
 }
 
 void NeoGeoSpy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 10; ++i) {
         Serial.write(rawData[i] ? ZERO : ONE);
     }
     Serial.write(SPLIT);
-#else
+}
+
+void NeoGeoSpy::debugSerial() {
     for(int i = 0; i < 10; ++i) {
         Serial.print(rawData[i] ? "0" : "1");
     }
     Serial.print("\n");
-#endif
 }
-
-

--- a/firmware/NeoGeo.h
+++ b/firmware/NeoGeo.h
@@ -8,6 +8,7 @@ class NeoGeoSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/PCFX.cpp
+++ b/firmware/PCFX.cpp
@@ -7,7 +7,11 @@ void PCFXSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void PCFXSpy::updateState() {
@@ -26,4 +30,8 @@ void PCFXSpy::updateState() {
 
 void PCFXSpy::writeSerial() {
     sendRawData(rawData, 0, PCFX_BITCOUNT);
+}
+
+void PCFXSpy::debugSerial() {
+    sendRawDataDebug(rawData, 0, PCFX_BITCOUNT);
 }

--- a/firmware/PCFX.h
+++ b/firmware/PCFX.h
@@ -8,6 +8,7 @@ class PCFXSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/PlayStation.cpp
+++ b/firmware/PlayStation.cpp
@@ -7,7 +7,11 @@ void PlayStationSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void PlayStationSpy::updateState() {
@@ -26,9 +30,7 @@ void PlayStationSpy::updateState() {
         byte pins = PIND;
 
         rawData[numBits] = pins & 0b01000000;
-#if defined(DEBUG)
         playstationCommand[numBits] = pins & 0b00100000;
-#endif
         numBits++;
     }
     while( ++bits < 8 );
@@ -82,7 +84,6 @@ void PlayStationSpy::updateState() {
 }
 
 void PlayStationSpy::writeSerial() {
-#ifndef DEBUG
     if (playstationCommand[0] == 0 && playstationCommand[1] != 0 && playstationCommand[2] == 0 && playstationCommand[3] == 0 && playstationCommand[4] == 0 && playstationCommand[5] == 0  && playstationCommand[6] != 0 && playstationCommand[7] == 0) {
         // playstationCommand=0x42 (Controller Poll)
         for (unsigned char i = 0; i < 152; ++i) {
@@ -90,7 +91,9 @@ void PlayStationSpy::writeSerial() {
         }
         Serial.write( SPLIT );
     }
-#else
+}
+
+void PlayStationSpy::debugSerial() {
     for(int i = 0; i < 152; ++i) {
         if (i % 8 == 0) {
             Serial.print("|");
@@ -98,5 +101,4 @@ void PlayStationSpy::writeSerial() {
         Serial.print(rawData[i] ? "1" : "0");
     }
     Serial.print("\n");
-#endif
 }

--- a/firmware/PlayStation.h
+++ b/firmware/PlayStation.h
@@ -8,13 +8,12 @@ class PlayStationSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:
         unsigned char rawData[152]; // 8 + 16 + 128
-#if defined(DEBUG)
         unsigned char playstationCommand[8];
-#endif
 };
 
 #endif

--- a/firmware/SMS.cpp
+++ b/firmware/SMS.cpp
@@ -149,14 +149,14 @@ void SMSSpy::debugSerial() {
         }
 
         Serial.print("-");
-        Serial.print((currentState & CS_BTN_UP)    ? "U" : "0");
-        Serial.print((currentState & CS_BTN_DOWN)  ? "D" : "0");
-        Serial.print((currentState & CS_BTN_LEFT)  ? "L" : "0");
-        Serial.print((currentState & CS_BTN_RIGHT) ? "R" : "0");
+        Serial.print((currentState & CC_BTN_UP)    ? "U" : "0");
+        Serial.print((currentState & CC_BTN_DOWN)  ? "D" : "0");
+        Serial.print((currentState & CC_BTN_LEFT)  ? "L" : "0");
+        Serial.print((currentState & CC_BTN_RIGHT) ? "R" : "0");
         Serial.print("0");
         Serial.print("0");
-        Serial.print((currentState & CS_BTN_1)     ? "1" : "0");
-        Serial.print((currentState & CS_BTN_2)     ? "2" : "0");
+        Serial.print((currentState & CC_BTN_1)     ? "1" : "0");
+        Serial.print((currentState & CC_BTN_2)     ? "2" : "0");
         Serial.print("0");
         Serial.print("0");
         Serial.print("0");

--- a/firmware/SMS.cpp
+++ b/firmware/SMS.cpp
@@ -63,7 +63,11 @@ void SMSSpy::setup() {
 
 void SMSSpy::loop() {
     updateState();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void SMSSpy::updateState() {
@@ -96,30 +100,13 @@ void SMSSpy::updateState() {
 void SMSSpy::writeSerial() {
     switch(outputType) {
     case OUTPUT_SMS:
-#ifndef DEBUG
         for (unsigned char i = 0; i < 6; ++i)
         {
             Serial.write (currentState & (1 << i) ? ONE : ZERO );
         }
         Serial.write( SPLIT );
-#else
-        if (currentState == lastState)
-        {
-            return;
-        }
-
-        Serial.print((currentState & CC_BTN_UP)    ? "U" : "0");
-        Serial.print((currentState & CC_BTN_DOWN)  ? "D" : "0");
-        Serial.print((currentState & CC_BTN_LEFT)  ? "L" : "0");
-        Serial.print((currentState & CC_BTN_RIGHT) ? "R" : "0");
-        Serial.print((currentState & CC_BTN_1)     ? "1" : "0");
-        Serial.print((currentState & CC_BTN_2)     ? "2" : "0");
-        Serial.print("\n");
-        lastState = currentState;
-#endif
         break;
     case OUTPUT_GENESIS:
-#ifndef DEBUG
         Serial.write(ZERO);
         Serial.write((currentState & CC_BTN_UP)    ? 1 : 0);
         Serial.write((currentState & CC_BTN_DOWN)  ? 1 : 0);
@@ -134,7 +121,28 @@ void SMSSpy::writeSerial() {
         Serial.write(ZERO);
         Serial.write(ZERO);
         Serial.write(SPLIT);
-#else
+        break;
+    }
+}
+
+void SMSSpy::debugSerial() {
+    switch(outputType) {
+    case OUTPUT_SMS:
+        if (currentState == lastState)
+        {
+            return;
+        }
+
+        Serial.print((currentState & CC_BTN_UP)    ? "U" : "0");
+        Serial.print((currentState & CC_BTN_DOWN)  ? "D" : "0");
+        Serial.print((currentState & CC_BTN_LEFT)  ? "L" : "0");
+        Serial.print((currentState & CC_BTN_RIGHT) ? "R" : "0");
+        Serial.print((currentState & CC_BTN_1)     ? "1" : "0");
+        Serial.print((currentState & CC_BTN_2)     ? "2" : "0");
+        Serial.print("\n");
+        lastState = currentState;
+        break;
+    case OUTPUT_GENESIS:
         if (currentState == lastState)
         {
             return;
@@ -155,7 +163,6 @@ void SMSSpy::writeSerial() {
         Serial.print("0");
         Serial.print("\n");
         lastState = currentState;
-#endif
         break;
     }
 }

--- a/firmware/SMS.h
+++ b/firmware/SMS.h
@@ -34,6 +34,7 @@ class SMSSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
         enum outputTypes {
@@ -58,6 +59,7 @@ class SMSSpy : public ControllerSpy {
 
         byte inputPins[CC_INPUT_PINS];
         word currentState;
+	word lastState = -1;
         unsigned long lastReadTime;
 };
 

--- a/firmware/SNES.cpp
+++ b/firmware/SNES.cpp
@@ -5,20 +5,27 @@ void SNESSpy::setup() {
 
 void SNESSpy::loop() {
     noInterrupts();
-#ifdef MODE_2WIRE_SNES
-    read_shiftRegister_2wire(SNES_LATCH, SNES_DATA, false, SNES_BITCOUNT);
-#else
     updateState();
-#endif
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void SNESSpy::writeSerial() {
     sendRawData(rawData, 0, bytesToReturn);
 }
 
+void SNESSpy::debugSerial() {
+    sendRawDataDebug(rawData, 0, bytesToReturn);
+}
+
 void SNESSpy::updateState() {
+#ifdef MODE_2WIRE_SNES
+    read_shiftRegister_2wire(rawData, SNES_LATCH, SNES_DATA, false, SNES_BITCOUNT);
+#else
     unsigned char position = 0;
     unsigned char bits = 0;
 
@@ -43,4 +50,5 @@ void SNESSpy::updateState() {
 
         bytesToReturn = SNES_BITCOUNT_EXT;
     }
+#endif
 }

--- a/firmware/SNES.h
+++ b/firmware/SNES.h
@@ -8,6 +8,7 @@ class SNESSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/Saturn.cpp
+++ b/firmware/Saturn.cpp
@@ -7,7 +7,11 @@ void SaturnSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
-    writeSerial()
+#if !defined(DEBUG)
+    writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void SaturnSpy::updateState() {
@@ -46,7 +50,6 @@ void SaturnSpy::updateState() {
 }
 
 void SaturnSpy::writeSerial() {
-#ifndef DEBUG
     for(int i = 0; i < 8; ++i) {
         Serial.write(i == 6 ? ONE : ZERO);
     }
@@ -75,7 +78,9 @@ void SaturnSpy::writeSerial() {
     }
 
     Serial.write( SPLIT );
-#else
+}
+
+void SaturnSpy::debugSerial() {
     Serial.print((ssState1 & 0b00000100)    ? "Z" : "0");
     Serial.print((ssState1 & 0b00001000)    ? "Y" : "0");
     Serial.print((ssState1 & 0b00010000)    ? "X" : "0");
@@ -94,5 +99,4 @@ void SaturnSpy::writeSerial() {
     Serial.print((ssState4 & 0b00100000)    ? "L" : "0");
 
     Serial.print("\n");
-#endif
 }

--- a/firmware/Saturn.h
+++ b/firmware/Saturn.h
@@ -8,6 +8,7 @@ class SaturnSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/Saturn3D.cpp
+++ b/firmware/Saturn3D.cpp
@@ -7,7 +7,11 @@ void Saturn3DSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
-    writeSerial()
+#if !defined(DEBUG)
+    writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void Saturn3DSpy::updateState() {
@@ -77,13 +81,14 @@ void Saturn3DSpy::updateState() {
 }
 
 void Saturn3DSpy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 56; ++i)
     {
         Serial.write( rawData[i] ? ONE : ZERO );
     }
     Serial.write( SPLIT );
-#else
+}
+
+void Saturn3DSpy::debugSerial() {
     for(int i = 0; i < 56; ++i)
     {
         if (i % 8 == 0) {
@@ -92,5 +97,4 @@ void Saturn3DSpy::writeSerial() {
         Serial.print(rawData[i] ? "1" : "0");
     }
     Serial.print("\n");
-#endif
 }

--- a/firmware/Saturn3D.h
+++ b/firmware/Saturn3D.h
@@ -8,6 +8,7 @@ class Saturn3DSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/TG16.cpp
+++ b/firmware/TG16.cpp
@@ -7,7 +7,11 @@ void TG16Spy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
     delay(1);
 }
 
@@ -49,24 +53,24 @@ void TG16Spy::updateState() {
 }
 
 void TG16Spy::writeSerial() {
-#ifndef DEBUG
     for (unsigned char i = 0; i < 12; ++i) {
-        Serial.write (currentState & (1 << i) ? ONE : ZERO );
+        Serial.write(currentState & (1 << i) ? ONE : ZERO);
     }
-    Serial.write( SPLIT );
-#else
-    Serial.print((currentState & 0b0000000000000001)    ? "U" : "0");
-    Serial.print((currentState & 0b0000000000000010)    ? "R" : "0");
-    Serial.print((currentState & 0b0000000000000100)    ? "D" : "0");
-    Serial.print((currentState & 0b0000000000001000)    ? "L" : "0");
-    Serial.print((currentState & 0b0000000000010000)    ? "A" : "0");
-    Serial.print((currentState & 0b0000000000100000)    ? "B" : "0");
-    Serial.print((currentState & 0b0000000001000000)    ? "S" : "0");
-    Serial.print((currentState & 0b0000000010000000)    ? "R" : "0");
-    Serial.print((currentState & 0b0000000100000000)    ? "3" : "0");
-    Serial.print((currentState & 0b0000001000000000)    ? "4" : "0");
-    Serial.print((currentState & 0b0000010000000000)    ? "5" : "0");
-    Serial.print((currentState & 0b0000100000000000)    ? "6" : "0");
+    Serial.write(SPLIT);
+}
+
+void TG16Spy::debugSerial() {
+    Serial.print((currentState & 0b0000000000000001) ? "U" : "0");
+    Serial.print((currentState & 0b0000000000000010) ? "R" : "0");
+    Serial.print((currentState & 0b0000000000000100) ? "D" : "0");
+    Serial.print((currentState & 0b0000000000001000) ? "L" : "0");
+    Serial.print((currentState & 0b0000000000010000) ? "A" : "0");
+    Serial.print((currentState & 0b0000000000100000) ? "B" : "0");
+    Serial.print((currentState & 0b0000000001000000) ? "S" : "0");
+    Serial.print((currentState & 0b0000000010000000) ? "R" : "0");
+    Serial.print((currentState & 0b0000000100000000) ? "3" : "0");
+    Serial.print((currentState & 0b0000001000000000) ? "4" : "0");
+    Serial.print((currentState & 0b0000010000000000) ? "5" : "0");
+    Serial.print((currentState & 0b0000100000000000) ? "6" : "0");
     Serial.print("\n");
-    #endif
 }

--- a/firmware/TG16.h
+++ b/firmware/TG16.h
@@ -8,6 +8,7 @@ class TG16Spy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:
@@ -16,6 +17,7 @@ class TG16Spy : public ControllerSpy {
         word lastButtons = 0;
         bool highButtons = true;
         bool seenHighButtons = false;
+        word currentState;
 };
 
 #endif

--- a/firmware/ThreeDO.cpp
+++ b/firmware/ThreeDO.cpp
@@ -7,7 +7,11 @@ void ThreeDOSpy::loop() {
     noInterrupts();
     updateState();
     interrupts();
+#if !defined(DEBUG)
     writeSerial();
+#else
+    debugSerial();
+#endif
 }
 
 void ThreeDOSpy::updateState() {
@@ -32,4 +36,8 @@ void ThreeDOSpy::updateState() {
 
 void ThreeDOSpy::writeSerial() {
     sendRawData(rawData, 0, bytesToReturn);
+}
+
+void ThreeDOSpy::debugSerial() {
+    sendRawDataDebug(rawData, 0, bytesToReturn);
 }

--- a/firmware/ThreeDO.h
+++ b/firmware/ThreeDO.h
@@ -8,6 +8,7 @@ class ThreeDOSpy : public ControllerSpy {
         void setup();
         void loop();
         void writeSerial();
+        void debugSerial();
         void updateState();
 
     private:

--- a/firmware/common.cpp
+++ b/firmware/common.cpp
@@ -1,20 +1,5 @@
 #include "common.h"
 
-// Declare some space to store the bits we read from a controller.
-unsigned char rawData[1024];
-word currentState = 0;
-word lastState = -1;
-
-void common_pin_setup()
-{
-  PORTD = 0x00;
-  PORTB = 0x00;
-  DDRD  = 0x00;
-
-  for(int i = 2; i <= 6; ++i)
-    pinMode(i, INPUT_PULLUP);
-}
-
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Performs a read cycle from a shift register based controller (SNES + NES) using only the data and latch
 // wires, and waiting a fixed time between reads.  This read method is deprecated due to being finicky,
@@ -23,7 +8,7 @@ void common_pin_setup()
 //     data  = Pin index on Port D where the output data wire is attached.
 //     bits  = Number of bits to read from the controller.
 //  longWait = The NES takes a bit longer between reads to get valid results back.
-void read_shiftRegister_2wire(unsigned char latch, unsigned char data, unsigned char longWait, unsigned char bits)
+void read_shiftRegister_2wire(unsigned char rawData[], unsigned char latch, unsigned char data, unsigned char longWait, unsigned char bits)
 {
     unsigned char *rawDataPtr = rawData;
 
@@ -57,13 +42,14 @@ read_loop:
 // Sends a packet of controller data over the Arduino serial interface.
 void sendRawData(unsigned char rawControllerData[], unsigned char first, unsigned char count)
 {
-    #ifndef DEBUG
     for( unsigned char i = first ; i < first + count ; i++ ) {
         Serial.write( rawControllerData[i] ? ONE : ZERO );
     }
     Serial.write( SPLIT );
-    #else
+}
 
+void sendRawDataDebug(unsigned char rawControllerData[], unsigned char first, unsigned char count)
+{
     for( unsigned char i = 0 ; i < first; i++ ) {
         Serial.print( rawControllerData[i] ? "1" : "0" );
     }
@@ -77,12 +63,4 @@ void sendRawData(unsigned char rawControllerData[], unsigned char first, unsigne
         ++j;
     }
     Serial.print("\n");
-    #endif
-}
-
-void sendRawData(unsigned char first, unsigned char count)
-{
-    // TODO: Get rid of this function.
-    // Use the global rawData
-    sendRawData(rawData, first, count);
 }

--- a/firmware/common.cpp
+++ b/firmware/common.cpp
@@ -1,5 +1,15 @@
 #include "common.h"
 
+void common_pin_setup()
+{
+  PORTD = 0x00;
+  PORTB = 0x00;
+  DDRD  = 0x00;
+
+  for(int i = 2; i <= 6; ++i)
+    pinMode(i, INPUT_PULLUP);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Performs a read cycle from a shift register based controller (SNES + NES) using only the data and latch
 // wires, and waiting a fixed time between reads.  This read method is deprecated due to being finicky,

--- a/firmware/common.h
+++ b/firmware/common.h
@@ -25,6 +25,7 @@
 #define ONE   '1'  // Use an ASCII one to represent a bit with value 1.  This makes Arduino debugging easier.
 #define SPLIT '\n'  // Use a new-line character to split up the controller state packets.
 
+void common_pin_setup();
 void read_shiftRegister_2wire(unsigned char rawData[], unsigned char latch, unsigned char data, unsigned char longWait, unsigned char bits);
 void sendRawData(unsigned char rawControllerData[], unsigned char first, unsigned char count);
 void sendRawDataDebug(unsigned char rawControllerData[], unsigned char first, unsigned char count);

--- a/firmware/common.h
+++ b/firmware/common.h
@@ -25,13 +25,6 @@
 #define ONE   '1'  // Use an ASCII one to represent a bit with value 1.  This makes Arduino debugging easier.
 #define SPLIT '\n'  // Use a new-line character to split up the controller state packets.
 
-// Declare some space to store the bits we read from a controller.
-extern unsigned char rawData[];
-extern word currentState;
-extern word lastState;
-
-void common_pin_setup();
-
-void read_shiftRegister_2wire(unsigned char latch, unsigned char data, unsigned char longWait, unsigned char bits);
-void sendRawData(unsigned char first, unsigned char count);
+void read_shiftRegister_2wire(unsigned char rawData[], unsigned char latch, unsigned char data, unsigned char longWait, unsigned char bits);
 void sendRawData(unsigned char rawControllerData[], unsigned char first, unsigned char count);
+void sendRawDataDebug(unsigned char rawControllerData[], unsigned char first, unsigned char count);


### PR DESCRIPTION
Split all of the existing writeSerial functions into separate writeSerial and debugSerial functions.  The Serial classes could eventually be overridden on devices like ATmega32U4, where there are more than 1 serial port present, to output controller data as well as debug data.

There is some minor cleanup interspersed.