### PR TITLE
Set nulls in POKKEN_BUTTONS to ls and rs in SwitchReader.cs

### DIFF
--- a/RetroSpyX/Readers/SwitchReader.cs
+++ b/RetroSpyX/Readers/SwitchReader.cs
@@ -13,7 +13,7 @@ namespace RetroSpy.Readers
         };
 
         private static readonly string?[] POKKEN_BUTTONS = {
-            "y", "b", "a", "x", "l", "r", "zl", "zr", "-", "+", null, null, "home", "capture"
+            "y", "b", "a", "x", "l", "r", "zl", "zr", "-", "+", "ls", "rs", "home", "capture"
         };
 
         private static float ReadStick(byte input)


### PR DESCRIPTION
Third-party Switch PowerA controllers have the same packet size as Pokken controllers, so `ls` and `rs` could not be used. This change declares the null fields in POKKEN_BUTTONS to those inputs, since (at least for PowerA controllers) they fit.